### PR TITLE
Fix newer versions of MixinSquared breaking older versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
 
     // MixinSquared
     include(implementation(
-        annotationProcessor("com.bawnorton.mixinsquared:mixinsquared-fabric:${project.property("mixinsquared_version")}")!!
+        annotationProcessor("com.github.bawnorton:mixinsquared-fabric:${project.property("mixinsquared_version")}")!!
     )!!)
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
 
     // MixinSquared
     include(implementation(
-        annotationProcessor("com.github.bawnorton:mixinsquared-fabric:${project.property("mixinsquared_version")}")!!
+        annotationProcessor("com.github.bawnorton.mixinsquared:mixinsquared-fabric:${project.property("mixinsquared_version")}")!!
     )!!)
 }
 


### PR DESCRIPTION
MixinSquared migrated from jitpack to my own maven when 0.2.0-beta.5 released, I did not know at the time that this would break compatibility with older versions of MixinSquared as the maven group changed from `com.github.bawnorton` to `com.bawnorton` causing mod loaders to think they were different mods. 

This PR reverts that change to allow for compatibility with older versions of MixinSquared.

 I aplogize for the inconvenience, I was not aware of the implications of this change.

_This PR was generated automatically_